### PR TITLE
fix: shows heading clearly in home and kitchen megamenu

### DIFF
--- a/responsive.css
+++ b/responsive.css
@@ -162,6 +162,9 @@
         width: auto;
         min-width: var(--percent100);
     }
+    .dpt-menu .mega .flexcol {
+        z-index: 1;
+    }
     .dpt-menu .has-child:hover .mega {
         display: flex;
     }


### PR DESCRIPTION
fix: shows heading clearly in home and kitchen megamenu #1 