### PR TITLE
fix: On closing the search box page do not refresh now

### DIFF
--- a/index.html
+++ b/index.html
@@ -1362,7 +1362,7 @@
             <div class="container">
                 <div class="wrapper">
                     <form action="" class="search">
-                        <a href="#" class="t-close search-close flexcenter"><i class="ri-close-line"></i></a>
+                        <a href="#0" class="t-close search-close flexcenter"><i class="ri-close-line"></i></a>
                         <span class="icon-lg"><i class="ri-search-line"></i></span>
                         <input type="search" name="" placeholder="Search for products" required>
                         <button type="submit">Search</button>


### PR DESCRIPTION
Before, on closing the search box that pops up when bottom menu search is triggered, the page refreshes. Now only the search box is closed and page do not refresh now